### PR TITLE
Replace WhatsHap with HiPhase

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,12 +180,12 @@ These files will be output for each sample defined in the cohort.
 | Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | small_variant_gvcfs | Small variants (SNPs and INDELs < 50bp) gVCFs called by [DeepVariant](https://github.com/google/deepvariant) (with index) | |
 | Array[File] | small_variant_vcf_stats | [`bcftools stats`](https://samtools.github.io/bcftools/bcftools.html#stats) summary statistics for small variants | |
 | Array[File] | small_variant_roh_bed | Regions of homozygosity determiend by [`bcftools roh`](https://samtools.github.io/bcftools/howtos/roh-calling.html) | |
-| Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | sample_sv_vcfs | Structural variants called by [pbsv](https://github.com/PacificBiosciences/pbsv) (with index) | |
-| Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | sample_phased_small_variant_vcfs | Small variants called by DeepVariant and phased by [WhatsHap](https://whatshap.readthedocs.io/en/latest/) (with index) | |
-| Array[File] | sample_whatshap_stats_tsvs | Phase block statistics written by [`whatshap stats`](https://whatshap.readthedocs.io/en/latest/guide.html#whatshap-stats) | |
-| Array[File] | sample_whatshap_stats_gtfs | Phase block GTF written by `whatshap stats` | |
-| Array[File] | sample_whatshap_stats_blocklists | Haplotype block list written by `whatshap stats` | |
-| Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | merged_haplotagged_bam | Aligned (by [pbmm2](https://github.com/PacificBiosciences/pbmm2)), haplotagged (by [`whatshap haplotag`](https://whatshap.readthedocs.io/en/latest/guide.html#visualizing-phasing-results)) reads (with index) | |
+| Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | sample_phased_small_variant_vcfs | Small variants called by DeepVariant and phased by [HiPhase](https://github.com/PacificBiosciences/HiPhase) (with index) | |
+| Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | sample_phased_sv_vcfs | Structural variants called by [pbsv](https://github.com/PacificBiosciences/pbsv) and phased by HiPhase (with index) | |
+| Array[File] | sample_hiphase_stats | Phase block summary statistics written by [HiPhase](https://github.com/PacificBiosciences/HiPhase/blob/main/docs/user_guide.md#chromosome-summary-file---summary-file) | |
+| Array[File] | sample_hiphase_blocks | Phase block list written by [HiPhase](https://github.com/PacificBiosciences/HiPhase/blob/main/docs/user_guide.md#phase-block-file---blocks-file) | |
+| Array[File] | sample_hiphase_haplotags | Per-read haplotag information, written by [HiPhase](https://github.com/PacificBiosciences/HiPhase/blob/main/docs/user_guide.md#haplotag-file---haplotag-file) | |
+| Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | merged_haplotagged_bam | Aligned (by [pbmm2](https://github.com/PacificBiosciences/pbmm2)), haplotagged (by [HiPhase](https://github.com/PacificBiosciences/HiPhase/blob/main/docs/user_guide.md#haplotagged-bam-files)) reads (with index) | |
 | Array[File] | haplotagged_bam_mosdepth_summary | [mosdepth](https://github.com/brentp/mosdepth) summary of median depths per chromosome | |
 | Array[File] | haplotagged_bam_mosdepth_region_bed | mosdepthhttps://github.com/brentp/mosdepth BED of median coverage depth per 500 bp window | |
 | Array[[IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)] | trgt_repeat_vcf | Tandem repeat genotypes from [TRGT](https://github.com/PacificBiosciences/trgt/blob/main/docs/vcf_files.md) (with index) | |
@@ -207,11 +207,11 @@ These files will be output if the cohort includes more than one sample.
 
 | Type | Name | Description | Notes |
 | :- | :- | :- | :- |
-| [IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)? | cohort_sv_vcf | Structural variants joint-called by [pbsv](https://github.com/PacificBiosciences/pbsv) (with index) | |
-| [IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)? | cohort_phased_joint_called_vcf | Small variants called by [DeepVariant](https://github.com/google/deepvariant), joint-called by [GLnexus](https://github.com/dnanexus-rnd/GLnexus), and phased by [WhatsHap](https://whatshap.readthedocs.io/en/latest/) (with index) | |
-| File? | cohort_whatshap_stats_tsvs | Phase block statistics written by [`whatshap stats`](https://whatshap.readthedocs.io/en/latest/guide.html#whatshap-stats)  | |
-| File? | cohort_whatshap_stats_gtfs | Phase block GTF written by `whatshap stats` | |
-| File? | cohort_whatshap_stats_blocklists | Haplotype block list written by `whatshap stats` | |
+| [IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)? | cohort_small_variant_vcf | Small variants called by [DeepVariant](https://github.com/google/deepvariant), joint-called by [GLnexus](https://github.com/dnanexus-rnd/GLnexus), and phased by [HiPhase](https://github.com/PacificBiosciences/HiPhase) (with index) | |
+| [IndexData](https://github.com/PacificBiosciences/wdl-common/blob/main/wdl/structs.wdl)? | cohort_sv_vcf | Structural variants joint-called by [pbsv](https://github.com/PacificBiosciences/pbsv) and phased by HiPhase (with index) | |
+| File? | cohort_hiphase_stats | Phase block summary statistics written by [HiPhase](https://github.com/PacificBiosciences/HiPhase/blob/main/docs/user_guide.md#chromosome-summary-file---summary-file) | |
+| File? | cohort_hiphase_blocks | Phase block list written by [HiPhase](https://github.com/PacificBiosciences/HiPhase/blob/main/docs/user_guide.md#phase-block-file---blocks-file) | |
+| File? | cohort_hiphase_haplotags | Per-read haplotag information, written by [HiPhase](https://github.com/PacificBiosciences/HiPhase/blob/main/docs/user_guide.md#haplotag-file---haplotag-file) | |
 
 ## Tertiary analysis
 
@@ -253,4 +253,4 @@ The Docker image used by a particular step of the workflow can be identified by 
 | slivar | <ul><li>[slivar 0.2.2](https://github.com/brentp/slivar/releases/tag/v0.2.2)</li><li>[bcftools 1.14](https://github.com/samtools/bcftools/releases/tag/1.14)</li><li>[vcfpy 0.13.3](https://github.com/bihealth/vcfpy/releases/tag/v0.13.3)</li><li>[pysam 0.19.1](https://github.com/pysam-developers/pysam/releases/tag/v0.19.1)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/987efde4d614a292fbfe9f3cf146b63005ad6a8a/docker/slivar) |
 | svpack | <ul><li>[svpack 36180ae6](https://github.com/PacificBiosciences/svpack/tree/a82598ebc4013bf32e70295b83b380ada6302c4a)</li><li>[pysam 0.16.0.1](https://github.com/pysam-developers/pysam/releases/tag/v0.16.0.1)</li> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/8598b47771995e44799575b72bde477c21bfc213/docker/svpack) |
 | trgt | <ul><li>[trgt 0.4.0](https://github.com/PacificBiosciences/trgt/releases/tag/v0.4.0)</li><li>[samtools 1.16.1](https://github.com/samtools/samtools/releases/tag/1.16.1)</li><li>[bcftools 1.16](https://github.com/samtools/bcftools/releases/tag/1.16)</li><li>[pysam 0.16.0.1](https://github.com/pysam-developers/pysam/releases/tag/v0.16.0.1)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/987efde4d614a292fbfe9f3cf146b63005ad6a8a/docker/trgt) |
-| whatshap | <ul><li>[whatshap 1.4](https://github.com/whatshap/whatshap/releases/tag/v1.4)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/987efde4d614a292fbfe9f3cf146b63005ad6a8a/docker/whatshap) |
+| hiphase | <ul><li>[HiPhase 0.10.2](https://github.com/PacificBiosciences/HiPhase/releases/tag/v0.10.2)</li><li>[samtools 1.16](https://github.com/samtools/samtools/releases/tag/1.16)</li><li>[bcftools 1.16](https://github.com/samtools/bcftools/releases/tag/1.16)</li></ul> | [Dockerfile](https://github.com/PacificBiosciences/wdl-dockerfiles/tree/48ec02a2eed235583934217417f5697f14931a1a/docker/hiphase) |

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -1067,7 +1067,6 @@
                 "hiphase_haplotags": {
                   "value": "${resources_file_path}/hiphase/HG005.GRCh38.hiphase.haplotags.tsv",
                   "test_tasks": [
-                    "calculate_md5sum",
                     "compare_file_basename",
                     "check_tab_delimited",
                     "count_columns"
@@ -1181,7 +1180,6 @@
                 "hiphase_haplotags": {
                   "value": "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.hiphase.haplotags.tsv",
                   "test_tasks": [
-                    "calculate_md5sum",
                     "compare_file_basename",
                     "check_tab_delimited",
                     "count_columns"

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -552,68 +552,6 @@
       "description": "",
       "tasks": {}
     },
-    "workflows/wdl-common/wdl/workflows/phase_vcf/phase_vcf.wdl": {
-      "key": "workflows/wdl-common/wdl/workflows/phase_vcf/phase_vcf.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "split_vcf": {
-          "key": "split_vcf",
-          "digest": "adwcwarx5ozmifuokiw2do4wapz3yd7n",
-          "tests": [
-            {
-              "inputs": {
-                "vcf": "${resources_file_path}/HG005.GRCh38.deepvariant.vcf.gz",
-                "vcf_index": "${resources_file_path}/HG005.GRCh38.deepvariant.vcf.gz.tbi",
-                "region": "chr6",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "region_vcf": {
-                  "value": "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.vcf.gz",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "vcftools_validator",
-                    "check_gzip"
-                  ]
-                }
-              }
-            }
-          ]
-        },
-        "bcftools_concat": {
-          "key": "bcftools_concat",
-          "digest": "khx3kb536qnzcxwsvovrdafc7de6l7pc",
-          "tests": [
-            {
-              "inputs": {
-                "vcfs": [
-                  "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.phased.vcf.gz",
-                  "${resources_file_path}/HG005.GRCh38.deepvariant.chr7.phased.vcf.gz"
-                ],
-                "vcf_indices": [
-                  "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.phased.vcf.gz.tbi",
-                  "${resources_file_path}/HG005.GRCh38.deepvariant.chr7.phased.vcf.gz.tbi"
-                ],
-                "output_vcf_name": "HG005.GRCh38.deepvariant.phased.vcf.gz",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "concatenated_vcf": {
-                  "value": "${resources_file_path}/HG005.GRCh38.deepvariant.phased.vcf.gz",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "vcftools_validator",
-                    "check_gzip"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
     "workflows/wdl-common/wdl/workflows/deepvariant/deepvariant.wdl": {
       "key": "workflows/wdl-common/wdl/workflows/deepvariant/deepvariant.wdl",
       "name": "",

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -1011,33 +1011,6 @@
         }
       }
     },
-    "workflows/wdl-common/wdl/tasks/pharmcat.wdl": {
-      "key": "workflows/wdl-common/wdl/tasks/pharmcat.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "pangu_cyp2d6": {
-          "key": "pangu_cyp2d6",
-          "digest": "",
-          "tests": []
-        },
-        "pharmcat_preprocess": {
-          "key": "pharmcat_preprocess",
-          "digest": "",
-          "tests": []
-        },
-        "filter_preprocessed_vcf": {
-          "key": "filter_preprocessed_vcf",
-          "digest": "",
-          "tests": []
-        },
-        "run_pharmcat": {
-          "key": "run_pharmcat",
-          "digest": "",
-          "tests": []
-        }
-      }
-    },
     "workflows/wdl-common/wdl/workflows/hiphase/hiphase.wdl": {
       "key": "workflows/wdl-common/wdl/workflows/hiphase/hiphase.wdl",
       "name": "",

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -956,13 +956,15 @@
       "tasks": {
         "run_hiphase": {
           "key": "run_hiphase",
-          "digest": "",
+          "digest": "z5kipmtsexf4ilkkxlvefvb3fhjiq2iz",
           "tests": [
             {
               "inputs": {
                 "id": "HG005",
                 "refname": "GRCh38",
-                "sample_ids": ["HG005"],
+                "sample_ids": [
+                  "HG005"
+                ],
                 "vcfs": [
                   "${resources_file_path}/HG005.GRCh38.deepvariant.vcf.gz",
                   "${resources_file_path}/HG005.GRCh38.pbsv.vcf.gz"

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -956,7 +956,7 @@
       "tasks": {
         "run_hiphase": {
           "key": "run_hiphase",
-          "digest": "z5kipmtsexf4ilkkxlvefvb3fhjiq2iz",
+          "digest": "tayo3gz26x6p7qtendjybf56hris2imt",
           "tests": [
             {
               "inputs": {

--- a/wdl-ci.config.json
+++ b/wdl-ci.config.json
@@ -341,55 +341,6 @@
         }
       }
     },
-    "workflows/wdl-common/wdl/tasks/whatshap_stats.wdl": {
-      "key": "workflows/wdl-common/wdl/tasks/whatshap_stats.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "whatshap_stats": {
-          "key": "whatshap_stats",
-          "digest": "fx6u534oxskfrvjpo57wpruv3qvuy6wd",
-          "tests": [
-            {
-              "inputs": {
-                "phased_vcf": "${resources_file_path}/HG005.GRCh38.deepvariant.phased.vcf.gz",
-                "phased_vcf_index": "${resources_file_path}/HG005.GRCh38.deepvariant.phased.vcf.gz",
-                "reference_chromosome_lengths": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.chr_lengths.txt",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "tsv": {
-                  "value": "${resources_file_path}/HG005.GRCh38.deepvariant.phased.tsv",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns"
-                  ]
-                },
-                "gtf": {
-                  "value": "${resources_file_path}/HG005.GRCh38.deepvariant.phased.gtf",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns"
-                  ]
-                },
-                "blocklist": {
-                  "value": "${resources_file_path}/HG005.GRCh38.deepvariant.phased.blocklist",
-                  "test_tasks": [
-                    "calculate_md5sum",
-                    "compare_file_basename",
-                    "check_tab_delimited",
-                    "count_columns"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
     "workflows/wdl-common/wdl/tasks/pbsv_discover.wdl": {
       "key": "workflows/wdl-common/wdl/tasks/pbsv_discover.wdl",
       "name": "",
@@ -440,90 +391,6 @@
                   "value": "${resources_file_path}/HG005.GRCh38.pbsv.vcf.gz",
                   "test_tasks": [
                     "calculate_md5sum",
-                    "compare_file_basename",
-                    "vcftools_validator",
-                    "check_gzip"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
-    "workflows/wdl-common/wdl/tasks/whatshap_haplotag.wdl": {
-      "key": "workflows/wdl-common/wdl/tasks/whatshap_haplotag.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "whatshap_haplotag": {
-          "key": "whatshap_haplotag",
-          "digest": "3lgrlpqwmyqwmtn325tllb7chycenhla",
-          "tests": [
-            {
-              "inputs": {
-                "phased_vcf": "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.vcf.gz",
-                "phased_vcf_index": "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.vcf.gz.tbi",
-                "aligned_bam": "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam",
-                "aligned_bam_index": "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam.bai",
-                "reference": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta",
-                "reference_index": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta.fai",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "haplotagged_bam": {
-                  "value": "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.haplotagged.bam",
-                  "test_tasks": [
-                    "compare_file_basename",
-                    "samtools_quickcheck"
-                  ]
-                }
-              }
-            }
-          ]
-        }
-      }
-    },
-    "workflows/wdl-common/wdl/tasks/whatshap_phase.wdl": {
-      "key": "workflows/wdl-common/wdl/tasks/whatshap_phase.wdl",
-      "name": "",
-      "description": "",
-      "tasks": {
-        "whatshap_phase": {
-          "key": "whatshap_phase",
-          "digest": "v6wsfphrdmgkzy6ecvdd5mzmq4l7fkfu",
-          "tests": [
-            {
-              "inputs": {
-                "vcf": "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.vcf.gz",
-                "vcf_index": "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.vcf.gz.tbi",
-                "chromosome": "chr6",
-                "aligned_bams": [
-                  "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam",
-                  "${resources_file_path}/HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.bam",
-                  "${resources_file_path}/HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.bam",
-                  "${resources_file_path}/HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.bam",
-                  "${resources_file_path}/HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.bam",
-                  "${resources_file_path}/HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.bam",
-                  "${resources_file_path}/HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.bam"
-                ],
-                "aligned_bam_indices": [
-                  "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam.bai",
-                  "${resources_file_path}/HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.bam.bai",
-                  "${resources_file_path}/HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.bam.bai",
-                  "${resources_file_path}/HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.bam.bai",
-                  "${resources_file_path}/HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.bam.bai",
-                  "${resources_file_path}/HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.bam.bai",
-                  "${resources_file_path}/HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.bam.bai"
-                ],
-                "reference": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta",
-                "reference_index": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta.fai",
-                "runtime_attributes": "${default_runtime_attributes}"
-              },
-              "output_tests": {
-                "phased_vcf": {
-                  "value": "${resources_file_path}/HG005.GRCh38.deepvariant.chr6.phased.vcf.gz",
-                  "test_tasks": [
                     "compare_file_basename",
                     "vcftools_validator",
                     "check_gzip"
@@ -1131,6 +998,277 @@
               "output_tests": {
                 "svpack_tsv": {
                   "value": "${resources_file_path}/hg005-small-cohort.GRCh38.pbsv.svpack.tsv",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_columns"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "workflows/wdl-common/wdl/tasks/pharmcat.wdl": {
+      "key": "workflows/wdl-common/wdl/tasks/pharmcat.wdl",
+      "name": "",
+      "description": "",
+      "tasks": {
+        "pangu_cyp2d6": {
+          "key": "pangu_cyp2d6",
+          "digest": "",
+          "tests": []
+        },
+        "pharmcat_preprocess": {
+          "key": "pharmcat_preprocess",
+          "digest": "",
+          "tests": []
+        },
+        "filter_preprocessed_vcf": {
+          "key": "filter_preprocessed_vcf",
+          "digest": "",
+          "tests": []
+        },
+        "run_pharmcat": {
+          "key": "run_pharmcat",
+          "digest": "",
+          "tests": []
+        }
+      }
+    },
+    "workflows/wdl-common/wdl/workflows/hiphase/hiphase.wdl": {
+      "key": "workflows/wdl-common/wdl/workflows/hiphase/hiphase.wdl",
+      "name": "",
+      "description": "",
+      "tasks": {
+        "run_hiphase": {
+          "key": "run_hiphase",
+          "digest": "",
+          "tests": [
+            {
+              "inputs": {
+                "id": "HG005",
+                "refname": "GRCh38",
+                "sample_ids": ["HG005"],
+                "vcfs": [
+                  "${resources_file_path}/HG005.GRCh38.deepvariant.vcf.gz",
+                  "${resources_file_path}/HG005.GRCh38.pbsv.vcf.gz"
+                ],
+                "vcf_indices": [
+                  "${resources_file_path}/HG005.GRCh38.deepvariant.vcf.gz.tbi",
+                  "${resources_file_path}/HG005.GRCh38.pbsv.vcf.gz.tbi"
+                ],
+                "phased_vcf_names": [
+                  "HG005.GRCh38.deepvariant.phased.vcf.gz",
+                  "HG005.GRCh38.pbsv.phased.vcf.gz"
+                ],
+                "phased_vcf_index_names": [
+                  "HG005.GRCh38.deepvariant.phased.vcf.gz.tbi",
+                  "HG005.GRCh38.pbsv.phased.vcf.gz.tbi"
+                ],
+                "bams": [
+                  "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.bam"
+                ],
+                "bam_indices": [
+                  "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.bam.bai"
+                ],
+                "haplotagged_bam_names": [
+                  "HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                  "HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                  "HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                  "HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                  "HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                  "HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                  "HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.haplotagged.bam"
+                ],
+                "haplotagged_bam_index_names": [
+                  "HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.haplotagged.bam.bai",
+                  "HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.haplotagged.bam.bai",
+                  "HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.haplotagged.bam.bai",
+                  "HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.haplotagged.bam.bai",
+                  "HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.haplotagged.bam.bai",
+                  "HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.haplotagged.bam.bai",
+                  "HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.haplotagged.bam.bai"
+                ],
+                "reference": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta",
+                "reference_index": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta.fai",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "phased_vcfs": {
+                  "value": [
+                    "${resources_file_path}/hiphase/HG005.GRCh38.deepvariant.phased.vcf.gz",
+                    "${resources_file_path}/hiphase/HG005.GRCh38.pbsv.phased.vcf.gz"
+                  ],
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "vcftools_validator",
+                    "check_gzip"
+                  ]
+                },
+                "haplotagged_bams": {
+                  "value": [
+                    "${resources_file_path}/hiphase/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                    "${resources_file_path}/hiphase/HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                    "${resources_file_path}/hiphase/HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                    "${resources_file_path}/hiphase/HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                    "${resources_file_path}/hiphase/HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                    "${resources_file_path}/hiphase/HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.haplotagged.bam",
+                    "${resources_file_path}/hiphase/HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.haplotagged.bam"
+                  ],
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "samtools_quickcheck"
+                  ]
+                },
+                "hiphase_stats": {
+                  "value": "${resources_file_path}/hiphase/HG005.GRCh38.hiphase.stats.tsv",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_columns"
+                  ]
+                },
+                "hiphase_blocks": {
+                  "value": "${resources_file_path}/hiphase/HG005.GRCh38.hiphase.blocks.tsv",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_columns"
+                  ]
+                },
+                "hiphase_haplotags": {
+                  "value": "${resources_file_path}/hiphase/HG005.GRCh38.hiphase.haplotags.tsv",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_columns"
+                  ]
+                }
+              }
+            },
+            {
+              "inputs": {
+                "id": "hg005-small-cohort",
+                "refname": "GRCh38",
+                "sample_ids": [
+                  "HG005",
+                  "HG006",
+                  "HG007"
+                ],
+                "vcfs": [
+                  "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.deepvariant.glnexus.vcf.gz",
+                  "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.pbsv.vcf.gz"
+                ],
+                "vcf_indices": [
+                  "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.deepvariant.glnexus.vcf.gz.tbi",
+                  "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.pbsv.vcf.gz.tbi"
+                ],
+                "phased_vcf_names": [
+                  "hg005-small-cohort.GRCh38.deepvariant.glnexus.phased.vcf.gz",
+                  "hg005-small-cohort.GRCh38.pbsv.phased.vcf.gz"
+                ],
+                "phased_vcf_index_names": [
+                  "hg005-small-cohort.GRCh38.deepvariant.glnexus.phased.vcf.gz.tbi",
+                  "hg005-small-cohort.GRCh38.pbsv.phased.vcf.gz.tbi"
+                ],
+                "bams": [
+                  "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG006.m64017_191209_211903.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG006.m64017_191211_182504.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG006.m64017_191213_003759.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG006.m64017_191214_070352.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG006.m64017_200107_170917.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG006.m64109_200210_210230.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG007.m64017_191216_194629.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG007.m64017_191218_164535.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG007.m64017_191219_225837.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG007.m64017_191221_052416.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG007.m64017_200108_232219.hifi_reads.GRCh38.aligned.bam",
+                  "${resources_file_path}/HG007.m64017_200112_090459.hifi_reads.GRCh38.aligned.bam"
+                ],
+                "bam_indices": [
+                  "${resources_file_path}/HG005.m64017_200723_190224.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64017_200730_190124.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64017_200801_011415.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64017_200802_073944.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64109_200304_195708.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64109_200309_192110.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG005.m64109_200311_013444.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG006.m64017_191209_211903.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG006.m64017_191211_182504.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG006.m64017_191213_003759.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG006.m64017_191214_070352.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG006.m64017_200107_170917.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG006.m64109_200210_210230.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG007.m64017_191216_194629.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG007.m64017_191218_164535.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG007.m64017_191219_225837.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG007.m64017_191221_052416.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG007.m64017_200108_232219.hifi_reads.GRCh38.aligned.bam.bai",
+                  "${resources_file_path}/HG007.m64017_200112_090459.hifi_reads.GRCh38.aligned.bam.bai"
+                ],
+                "haplotagged_bam_names": [],
+                "haplotagged_bam_index_names": [],
+                "reference": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta",
+                "reference_index": "${datasets_file_path}/GRCh38/human_GRCh38_no_alt_analysis_set.fasta.fai",
+                "runtime_attributes": "${default_runtime_attributes}"
+              },
+              "output_tests": {
+                "phased_vcfs": {
+                  "value": [
+                    "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.deepvariant.glnexus.phased.vcf.gz",
+                    "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.pbsv.phased.vcf.gz"
+                  ],
+                  "test_tasks": [
+                    "compare_file_basename",
+                    "vcftools_validator",
+                    "check_gzip"
+                  ]
+                },
+                "hiphase_stats": {
+                  "value": "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.hiphase.stats.tsv",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_columns"
+                  ]
+                },
+                "hiphase_blocks": {
+                  "value": "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.hiphase.blocks.tsv",
+                  "test_tasks": [
+                    "calculate_md5sum",
+                    "compare_file_basename",
+                    "check_tab_delimited",
+                    "count_columns"
+                  ]
+                },
+                "hiphase_haplotags": {
+                  "value": "${resources_file_path}/hiphase/hg005-small-cohort.GRCh38.hiphase.haplotags.tsv",
                   "test_tasks": [
                     "calculate_md5sum",
                     "compare_file_basename",

--- a/workflows/cohort_analysis/cohort_analysis.wdl
+++ b/workflows/cohort_analysis/cohort_analysis.wdl
@@ -6,12 +6,12 @@ import "../humanwgs_structs.wdl"
 import "../wdl-common/wdl/tasks/pbsv_call.wdl" as PbsvCall
 import "../wdl-common/wdl/tasks/zip_index_vcf.wdl" as ZipIndexVcf
 import "../wdl-common/wdl/tasks/glnexus.wdl" as Glnexus
-import "../wdl-common/wdl/workflows/phase_vcf/phase_vcf.wdl" as PhaseVcf
+import "../wdl-common/wdl/workflows/hiphase/hiphase.wdl" as HiPhase
 
 workflow cohort_analysis {
 	input {
 		String cohort_id
-		Int sample_count
+		Array[String] sample_ids
 		Array[IndexData] aligned_bams
 		Array[File] svsigs
 		Array[IndexData] gvcfs
@@ -23,6 +23,8 @@ workflow cohort_analysis {
 
 		RuntimeAttributes default_runtime_attributes
 	}
+
+	Int sample_count = length(sample_ids)
 
 	scatter (gvcf_object in gvcfs) {
 		File gvcf = gvcf_object.data
@@ -57,28 +59,32 @@ workflow cohort_analysis {
 			runtime_attributes = default_runtime_attributes
 	}
 
-	call PhaseVcf.phase_vcf {
+	call HiPhase.hiphase {
+		# VCF order: small variants, SVs
 		input:
-			vcf = {"data": glnexus.vcf, "data_index": glnexus.vcf_index},
-			aligned_bams = aligned_bams,
+			id = cohort_id,
+			refname = reference.name,
+			sample_ids = sample_ids,
+			vcfs = [{"data": glnexus.vcf, "data_index": glnexus.vcf_index}, {"data": zip_index_vcf.zipped_vcf, "data_index": zip_index_vcf.zipped_vcf_index}],
+			bams = aligned_bams,
+			haplotag = false,
 			reference_fasta = reference.fasta,
-			reference_chromosome_lengths = reference.chromosome_lengths,
-			regions = reference.chromosomes,
 			default_runtime_attributes = default_runtime_attributes
 	}
 
 	output {
-		IndexData sv_vcf = {"data": zip_index_vcf.zipped_vcf, "data_index": zip_index_vcf.zipped_vcf_index}
-		IndexData phased_joint_called_vcf = phase_vcf.phased_vcf
-		File whatshap_stats_gtf = phase_vcf.whatshap_stats_gtf
-		File whatshap_stats_tsv = phase_vcf.whatshap_stats_tsv
-		File whatshap_stats_blocklist = phase_vcf.whatshap_stats_blocklist
+		IndexData phased_joint_small_variant_vcf = hiphase.phased_vcfs[0]
+		IndexData phased_joint_sv_vcf = hiphase.phased_vcfs[1]
+		File hiphase_stats = hiphase.hiphase_stats
+		File hiphase_blocks = hiphase.hiphase_blocks
+		File hiphase_haplotags = hiphase.hiphase_haplotags
 	}
 
 	parameter_meta {
-		cohort_id: {help: "Sample ID for the cohort; used for naming files"}
-		aligned_bams: {help: "Bam and index aligned to the reference genome for each movie associated with all samples in the cohort"}
-		svsigs: {help: "pbsv svsig files for each sample and movie bam in the cohort"}
+		cohort_id: {help: "Cohort ID; used for naming files"}
+		sample_ids: {help: "Sample IDs for all samples in the cohort"}
+		aligned_bams: {help: "BAM and index aligned to the reference genome for each movie associated with all samples in the cohort"}
+		svsigs: {help: "pbsv svsig files for each sample and movie BAM in the cohort"}
 		gvcfs: {help: "gVCF for each sample in the cohort"}
 		reference: {help: "Reference genome data"}
 		pbsv_call_mem_gb: {help: "Optional amount of RAM in GB for pbsv_call; default 64 for cohorts N<=3, 96 for cohorts N>3"}

--- a/workflows/cohort_analysis/cohort_analysis.wdl
+++ b/workflows/cohort_analysis/cohort_analysis.wdl
@@ -49,6 +49,11 @@ workflow cohort_analysis {
 			runtime_attributes = default_runtime_attributes
 	}
 
+	IndexData zipped_pbsv_vcf = {
+		"data": zip_index_vcf.zipped_vcf,
+		"data_index": zip_index_vcf.zipped_vcf_index
+	}
+
 	call Glnexus.glnexus {
 		input:
 			cohort_id = cohort_id,
@@ -59,13 +64,18 @@ workflow cohort_analysis {
 			runtime_attributes = default_runtime_attributes
 	}
 
+	IndexData glnexus_vcf = {
+		"data": glnexus.vcf,
+		"data_index": glnexus.vcf_index
+	}
+
 	call HiPhase.hiphase {
 		# VCF order: small variants, SVs
 		input:
 			id = cohort_id,
 			refname = reference.name,
 			sample_ids = sample_ids,
-			vcfs = [{"data": glnexus.vcf, "data_index": glnexus.vcf_index}, {"data": zip_index_vcf.zipped_vcf, "data_index": zip_index_vcf.zipped_vcf_index}],
+			vcfs = [glnexus_vcf, zipped_pbsv_vcf],
 			bams = aligned_bams,
 			haplotag = false,
 			reference_fasta = reference.fasta,

--- a/workflows/cohort_analysis/inputs.json
+++ b/workflows/cohort_analysis/inputs.json
@@ -1,6 +1,6 @@
 {
   "cohort_analysis.cohort_id": "String",
-  "cohort_analysis.sample_count": "Int",
+  "cohort_analysis.sample_ids": "Array[String]",
   "cohort_analysis.aligned_bams": [
     {
       "data": "File",

--- a/workflows/main.wdl
+++ b/workflows/main.wdl
@@ -54,10 +54,15 @@ workflow humanwgs {
 	}
 
 	if (length(cohort.samples) > 1) {
+
+		scatter (sample in cohort.samples) {
+			String sample_id = sample.sample_id
+		}
+		
 		call CohortAnalysis.cohort_analysis {
 			input:
 				cohort_id = cohort.cohort_id,
-				sample_count = length(cohort.samples),
+				sample_ids = sample_id,
 				aligned_bams = flatten(sample_analysis.aligned_bams),
 				svsigs = flatten(sample_analysis.svsigs),
 				gvcfs = sample_analysis.small_variant_gvcf,
@@ -70,12 +75,12 @@ workflow humanwgs {
 
 	if (run_tertiary_analysis) {
 		IndexData slivar_small_variant_input_vcf = select_first([
-			cohort_analysis.phased_joint_called_vcf,
+			cohort_analysis.phased_joint_small_variant_vcf,
 			sample_analysis.phased_small_variant_vcf[0]
 		])
 		IndexData slivar_sv_input_vcf = select_first([
-			cohort_analysis.sv_vcf,
-			sample_analysis.sv_vcf[0]
+			cohort_analysis.phased_joint_sv_vcf,
+			sample_analysis.phased_sv_vcf[0]
 		])
 
 		call TertiaryAnalysis.tertiary_analysis {
@@ -97,11 +102,11 @@ workflow humanwgs {
 		Array[IndexData] small_variant_gvcfs = sample_analysis.small_variant_gvcf
 		Array[File] small_variant_vcf_stats = sample_analysis.small_variant_vcf_stats
 		Array[File] small_variant_roh_bed = sample_analysis.small_variant_roh_bed
-		Array[IndexData] sample_sv_vcfs = sample_analysis.sv_vcf
 		Array[IndexData] sample_phased_small_variant_vcfs = sample_analysis.phased_small_variant_vcf
-		Array[File] sample_whatshap_stats_gtfs = sample_analysis.whatshap_stats_gtf
-		Array[File] sample_whatshap_stats_tsvs = sample_analysis.whatshap_stats_tsv
-		Array[File] sample_whatshap_stats_blocklists = sample_analysis.whatshap_stats_blocklist
+		Array[IndexData] sample_phased_sv_vcfs = sample_analysis.phased_sv_vcf
+		Array[File] sample_hiphase_stats = sample_analysis.hiphase_stats
+		Array[File] sample_hiphase_blocks = sample_analysis.hiphase_blocks
+		Array[File] sample_hiphase_haplotags = sample_analysis.hiphase_haplotags
 		Array[IndexData] merged_haplotagged_bam = sample_analysis.merged_haplotagged_bam
 		Array[File] haplotagged_bam_mosdepth_summary = sample_analysis.haplotagged_bam_mosdepth_summary
 		Array[File] haplotagged_bam_mosdepth_region_bed = sample_analysis.haplotagged_bam_mosdepth_region_bed
@@ -119,11 +124,11 @@ workflow humanwgs {
 		Array[File] hificnv_maf_bws = sample_analysis.hificnv_maf_bw
 
 		# cohort_analysis output
-		IndexData? cohort_sv_vcf = cohort_analysis.sv_vcf
-		IndexData? cohort_phased_joint_called_vcf = cohort_analysis.phased_joint_called_vcf
-		File? cohort_whatshap_stats_gtfs = cohort_analysis.whatshap_stats_gtf
-		File? cohort_whatshap_stats_tsvs = cohort_analysis.whatshap_stats_tsv
-		File? cohort_whatshap_stats_blocklists = cohort_analysis.whatshap_stats_blocklist
+		IndexData? cohort_sv_vcf = cohort_analysis.phased_joint_sv_vcf
+		IndexData? cohort_small_variant_vcf = cohort_analysis.phased_joint_small_variant_vcf
+		File? cohort_hiphase_stats = cohort_analysis.hiphase_stats
+		File? cohort_hiphase_blocks = cohort_analysis.hiphase_blocks
+		File? cohort_hiphase_haplotags = cohort_analysis.hiphase_haplotags
 
 		# tertiary_analysis output
 		IndexData? filtered_small_variant_vcf = tertiary_analysis.filtered_small_variant_vcf

--- a/workflows/main.wdl
+++ b/workflows/main.wdl
@@ -96,12 +96,18 @@ workflow humanwgs {
 
 	output {
 		# sample_analysis output
+
+		# per movie stats, alignments
 		Array[Array[File]] bam_stats = sample_analysis.bam_stats
 		Array[Array[File]] read_length_summary = sample_analysis.read_length_summary
 		Array[Array[File]] read_quality_summary = sample_analysis.read_quality_summary
+
+		# per sample small variant calls
 		Array[IndexData] small_variant_gvcfs = sample_analysis.small_variant_gvcf
 		Array[File] small_variant_vcf_stats = sample_analysis.small_variant_vcf_stats
 		Array[File] small_variant_roh_bed = sample_analysis.small_variant_roh_bed
+
+		# per sample final phased variant calls and haplotagged alignments
 		Array[IndexData] sample_phased_small_variant_vcfs = sample_analysis.phased_small_variant_vcf
 		Array[IndexData] sample_phased_sv_vcfs = sample_analysis.phased_sv_vcf
 		Array[File] sample_hiphase_stats = sample_analysis.hiphase_stats
@@ -110,14 +116,22 @@ workflow humanwgs {
 		Array[IndexData] merged_haplotagged_bam = sample_analysis.merged_haplotagged_bam
 		Array[File] haplotagged_bam_mosdepth_summary = sample_analysis.haplotagged_bam_mosdepth_summary
 		Array[File] haplotagged_bam_mosdepth_region_bed = sample_analysis.haplotagged_bam_mosdepth_region_bed
+		
+		# per sample trgt outputs
 		Array[IndexData] trgt_spanning_reads = sample_analysis.trgt_spanning_reads
 		Array[IndexData] trgt_repeat_vcf = sample_analysis.trgt_repeat_vcf
 		Array[File] trgt_dropouts = sample_analysis.trgt_dropouts
+
+		# per sample cpg outputs
 		Array[Array[File]] cpg_pileup_beds = sample_analysis.cpg_pileup_beds
 		Array[Array[File]] cpg_pileup_bigwigs = sample_analysis.cpg_pileup_bigwigs
+
+		# per sample paraphase outputs
 		Array[File] paraphase_output_jsons = sample_analysis.paraphase_output_json
 		Array[IndexData] paraphase_realigned_bams = sample_analysis.paraphase_realigned_bam
 		Array[Array[File]] paraphase_vcfs = sample_analysis.paraphase_vcfs
+
+		# per sample hificnv outputs
 		Array[IndexData] hificnv_vcfs = sample_analysis.hificnv_vcf
 		Array[File] hificnv_copynum_bedgraphs = sample_analysis.hificnv_copynum_bedgraph
 		Array[File] hificnv_depth_bws = sample_analysis.hificnv_depth_bw


### PR DESCRIPTION
- Depends on https://github.com/PacificBiosciences/wdl-common/pull/19
- HiPhase set to phase both DeepVariant and PBSV output, using aligned HiFi BAMs.
- For sample_analysis, generates haplotagged BAMs as well.
- For cohort_analysis, simultaneously phases all samples in cohort, but does not haplotag BAMs.
- Documentation updated.